### PR TITLE
<slot/> was deprecated

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -9,7 +9,7 @@
 <div class="min-h-screen bg-gray-50">
 	<GNB />
 	<main>
-  {@render children()}
+  {@render children()} 
 		<!-- {#if children}
 			{@html children}
 		{/if} -->


### PR DESCRIPTION
##변경점
<slot/>  => {@render ...}
##개요 
<slot/> was deprecated
##참조

## Summary by Sourcery

Enhancements:
- Replace <slot/> with {@render children()}.